### PR TITLE
Types: Added damage type `magic`

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -123,6 +123,7 @@
   "Damage.Fire": "Fire",
   "Damage.Force": "Force",
   "Damage.Lightning": "Lightning",
+  "Damage.Magic": "Magic",
   "Damage.Necrotic": "Necrotic",
   "Damage.Piercing": "Piercing",
   "Damage.Poison": "Poison",

--- a/types.json
+++ b/types.json
@@ -191,6 +191,7 @@
     "fire": "Damage.Fire",
     "force": "Damage.Force",
     "lightning": "Damage.Lightning",
+    "magic": "Damage.Magic",
     "necrotic": "Damage.Necrotic",
     "piercing": "Damage.Piercing",
     "poison": "Damage.Poison",


### PR DESCRIPTION
Added a `magic` damage type. It could be useful in setting damage vulnerabilities and resistances for NPCs and monsters (like for example `Archmage`)