### PR TITLE
suppress empty alignment

### DIFF
--- a/views/partials/monster-stats.json
+++ b/views/partials/monster-stats.json
@@ -23,7 +23,7 @@
                 },
                 {
                   "style": "subtitle",
-                  "value": "*{{data.size|map: 'Size'}} {{data.type|map: 'MonsterType'}}{% if data.typeDetail %} ({{data.typeDetail}}){% endif %}, {{data.alignment|map: 'Alignment'}}*",
+                  "value": "*{{data.size|map: 'Size'}} {{data.type|map: 'MonsterType'}}{% if data.typeDetail %} ({{data.typeDetail}}){% endif %}{% if data.alignment %}, {{data.alignment|map: 'Alignment'}}{% endif %}*",
                 },
                 {
                   "style": "subtitle",


### PR DESCRIPTION
if alignment is empty, then it breaks the markdown display, so we should suppress it