### PR TITLE
suppress non-attack actions

### DIFF
--- a/views/partials/character-action.json
+++ b/views/partials/character-action.json
@@ -13,7 +13,7 @@
     },
     {
       "type": "image",
-      "value": "{% if definition.imagePath == nil %}/icons/attack/{{attackType}}.png{% endif %}",
+      "value": "{% if attackType != nil %}/icons/attack/{{attackType}}.png{% endif %}",
       "imageResizeMode": "aspectFill",
       "cornerRadius": 6,
       "width": 34,


### PR DESCRIPTION
This will prevent non-attack actions from showing a broken image